### PR TITLE
Add v4l2sink plugin support

### DIFF
--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -34,6 +34,12 @@
       "add-ld-path": ".",
       "no-autodownload": true,
       "autodelete": true
+    },
+    "com.obsproject.Studio.V4L2Sink": {
+      "directory": "lib/v4l2sink",
+      "add-ld-path": ".",
+      "no-autodownload": true,
+      "autodelete": true
     }
   },
   "cleanup": [
@@ -207,10 +213,11 @@
         "-DOBS_VERSION_OVERRIDE=25.0.8"
       ],
       "post-install": [
-        "install -d /app/lib/blackmagic /app/lib/ndi",
+        "install -d /app/lib/blackmagic /app/lib/ndi /app/lib/v4l2sink",
         "ln -s /app/lib/ndi/obs-ndi.so /app/lib/obs-plugins/obs-ndi.so",
         "mkdir -p /app/share/obs/obs-plugins/obs-ndi",
-        "ln -s /app/lib/ndi/locale /app/share/obs/obs-plugins/obs-ndi/locale"
+        "ln -s /app/lib/ndi/locale /app/share/obs/obs-plugins/obs-ndi/locale",
+        "ln -s /app/lib/v4l2sink/v4l2sink.so /app/lib/obs-plugins/obs-v4l2sink.so"
       ],
       "sources": [
         {


### PR DESCRIPTION
This pull request adds support for [obs-v4l2sink](https://github.com/CatxFish/obs-v4l2sink/) plugin which can be installed with the similar manner as NDI/BlackMagic support and solves #65.

I decided to use HEAD of `obs-v4l2sink` instead of `v0.1` as HEAD contains several build fixes and it doesn't seems like there's going to be a new release anytime soon.

I've tested this with several apps, e.g. Google Meet, Flatpak Zoom and it has been working fine.

-----

Until this is merged, the steps to use goes among the following line:

1. Install `flatpak-builder`
2. Clone the repo and switch to appropriate branch `v4lsink-support` (_sic_):
    ```
    $ git clone --branch=v4lsink-support https://github.com/sirn/com.obsproject.Studio
    $ git clone --branch=com.obsproject.Studio.V4L2Sink https://github.com/sirn/flathub com.obsproject.Studio.V4L2Sink
    ```
3. Install a custom OBS Studio (for extension support):
    ```
    $ cd com.obsproject.Studio
    $ flatpak-builder --force-clean build-dir com.obsproject.Studio.json --user --install
    $ cd ..
4. Install V4L2Sink plugin
    ```
    $ cd com.obsproject.Studio.V4L2Sink
    $ flatpak-builder --force-clean build-dir com.obsproject.Studio.V4L2Sink.json --user --install
    $ cd ..
    ```

To use the V4L2Sink plugin:

1. Install [`v4l2loopback` DKMS](https://github.com/umlaeute/v4l2loopback)
2. Load the kernel module:
    ```
    # modprobe v4l2loopback
    ```
3. Launch OBS and go to Tools -> V4l2sink, and select the loopback video input 