### PR TITLE
JACK, take 2

### DIFF
--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -204,15 +204,12 @@
       "name": "jack2",
       "buildsystem": "simple",
       "build-commands": [
-        "./waf configure --prefix=/app --htmldir=/app/share/doc/jack/ --classic",
+        "./waf configure --prefix=$FLATPAK_DEST",
         "./waf build -j $FLATPAK_BUILDER_N_JOBS",
         "./waf install"
       ],
       "cleanup": [
-        "/bin",
-        "/share",
-        "/lib/jack",
-        "/lib/libjackserver.so*"
+        "*"
       ],
       "sources": [
         {

--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -220,23 +220,6 @@
       ]
     },
     {
-      "name": "pipewire",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dalsa=false",
-        "-Dbluez5=false",
-        "-Dexamples=false",
-        "-Dman=false",
-        "-Dtests=false"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.freedesktop.org/pipewire/pipewire.git"
-        }
-      ]
-    },
-    {
       "name": "obs",
       "buildsystem": "cmake-ninja",
       "builddir": true,


### PR DESCRIPTION
They're provided by the FreeDesktop 20.08 runtime now. Not
having the JACK library means PipeWire will be used as a
fallback mechanism.