### PR TITLE
Add generic plugin extension point

### DIFF
--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -26,7 +26,8 @@
     "com.obsproject.Studio.Plugin": {
       "directory": "plugins",
       "subdirectories": true,
-      "merge-dirs": "lib;share",
+      "add-ld-path": "lib",
+      "merge-dirs": "lib/obs-plugins;share/obs/obs-plugins",
       "no-autodownload": true,
       "autodelete": true
     },

--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -23,6 +23,13 @@
     "--system-talk-name=org.freedesktop.Avahi"
   ],
   "add-extensions": {
+    "com.obsproject.Studio.Plugin": {
+      "directory": "plugins",
+      "subdirectories": true,
+      "merge-dirs": "lib;share",
+      "no-autodownload": true,
+      "autodelete": true
+    },
     "com.obsproject.Studio.BlackMagicLibs": {
       "directory": "lib/blackmagic",
       "add-ld-path": ".",
@@ -240,6 +247,9 @@
         "-DOBS_VERSION_OVERRIDE=26.1.1"
       ],
       "post-install": [
+        /* Generic extension point */
+        "install -d /app/plugins",
+        /* Non-generic extension links */
         "install -d /app/lib/blackmagic /app/lib/ndi /app/lib/v4l2sink",
         "ln -s /app/lib/ndi/obs-ndi.so /app/lib/obs-plugins/obs-ndi.so",
         "mkdir -p /app/share/obs/obs-plugins/obs-ndi",
@@ -252,6 +262,10 @@
           "url": "https://github.com/obsproject/obs-studio.git",
           "tag": "26.1.1",
           "commit": "dffa8221124106bc2a4c92e5f5d0fa21128a61f6"
+        },
+        {
+          "type": "patch",
+          "path": "obs-plugins-dir.patch"
         }
       ]
     },

--- a/obs-plugins-dir.patch
+++ b/obs-plugins-dir.patch
@@ -1,0 +1,17 @@
+--- a/libobs/obs-nix.c	2021-01-26 00:31:31.853462587 -0500
++++ b/libobs/obs-nix.c	2021-01-26 00:35:18.229645660 -0500
+@@ -54,11 +54,13 @@
+ 
+ static const char *module_bin[] = {"../../obs-plugins/" BIT_STRING,
+ 				   OBS_INSTALL_PREFIX
+-				   "/" OBS_PLUGIN_DESTINATION};
++				   "/" OBS_PLUGIN_DESTINATION,
++				   "/app/plugins/lib/obs-plugins"};
+ 
+ static const char *module_data[] = {
+ 	OBS_DATA_PATH "/obs-plugins/%module%",
+ 	OBS_INSTALL_DATA_PATH "/obs-plugins/%module%",
++	"/app/plugins/share/obs/obs-plugins/%module%",
+ };
+ 
+ static const int module_patterns_size =


### PR DESCRIPTION
This branch was named new-plugins because I originally wanted to also add the input-overlay plugin as well. Unfortunately, it's a pain to compile because its CMake files don't let you define where OBS's source is. It expects you to clone the git repo as a subdir inside of OBS's source: https://github.com/univrsal/input-overlay/wiki/Compiling

But I do have obs-websocket compiled and working, so I guess we'll start with just that for now.