### PR TITLE
JACK

### DIFF
--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -260,6 +260,23 @@
             ]
         },
         {
+            "name": "jack2",
+            "buildsystem": "simple",
+            "build-commands": [
+                "./waf configure --prefix=$FLATPAK_DEST",
+                "./waf build -j $FLATPAK_BUILDER_N_JOBS",
+                "./waf install"
+            ],
+            "cleanup": [ "*" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz",
+                    "sha256": "a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c"
+                }
+            ]
+        },
+        {
             "name": "obs",
             "buildsystem": "cmake-ninja",
             "builddir": true,
@@ -268,7 +285,6 @@
                 "-DUNIX_STRUCTURE=ON",
                 "-DUSE_XDG=ON",
                 "-DDISABLE_ALSA=ON",
-                "-DDISABLE_JACK=ON",
                 "-DENABLE_PULSEAUDIO=ON",
                 "-DWITH_RTMPS=ON",
                 "-DOBS_VERSION_OVERRIDE=26.1.1"


### PR DESCRIPTION
With PipeWire 0.3.23 available in the FreeDesktop platform, we can try and enable JACK support on OBS Studio.