### PR TITLE
27.0.0-rc1 (Flathub Beta)

### DIFF
--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -272,12 +272,39 @@
             ]
         },
         {
+            "name": "cef",
+            "buildsystem": "cmake-ninja",
+            "no-make-install": true,
+            "make-args": [
+                "libcef_dll_wrapper"
+            ],
+            "build-commands": [
+                "mkdir -p /app/cef/libcef_dll_wrapper",
+                "cp -R ./include /app/cef",
+                "cp -R ./Release /app/cef",
+                "cp -R ./Resources /app/cef",
+                "cp -R ./libcef_dll_wrapper/libcef_dll_wrapper.a /app/cef/libcef_dll_wrapper"
+            ],
+            "cleanup": [
+                "./*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://cdn-fastly.obsproject.com/downloads/cef_binary_4280_linux64.tar.bz2",
+                    "sha256": "d91c78349ecbfbfdfc18d5f882dc28b939028f1a631191c603b5d0d938ada972"
+                }
+            ]
+        },
+        {
             "name": "obs",
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DENABLE_WAYLAND=ON",
+                "-DBUILD_BROWSER=ON",
+                "-DCEF_ROOT_DIR=/app/cef",
                 "-DUNIX_STRUCTURE=ON",
                 "-DUSE_XDG=ON",
                 "-DDISABLE_ALSA=ON",

--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -7,12 +7,13 @@
     "command": "obs",
     "finish-args": [
         "--socket=x11",
+        "--socket=wayland",
         "--socket=pulseaudio",
         "--device=all",
         "--share=network",
         "--share=ipc",
-        "--filesystem=xdg-run/obs-xdg-portal:create",
         "--filesystem=host",
+        "--filesystem=xdg-run/pipewire-0",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.freedesktop.PowerManagement.Inhibit",
@@ -276,12 +277,14 @@
             "builddir": true,
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
+                "-DENABLE_WAYLAND=ON",
                 "-DUNIX_STRUCTURE=ON",
                 "-DUSE_XDG=ON",
                 "-DDISABLE_ALSA=ON",
                 "-DENABLE_PULSEAUDIO=ON",
+                "-DENABLE_PIPEWIRE=ON",
                 "-DWITH_RTMPS=ON",
-                "-DOBS_VERSION_OVERRIDE=26.1.1"
+                "-DOBS_VERSION_OVERRIDE=27.0.0-rc1"
             ],
             "post-install": [
                 "install -d /app/plugins",
@@ -295,26 +298,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/obsproject/obs-studio.git",
-                    "tag": "26.1.1",
-                    "commit": "dffa8221124106bc2a4c92e5f5d0fa21128a61f6"
+                    "tag": "27.0.0-rc1",
+                    "commit": "334146ee36f8751f92b54716c4ea88f4a88f453d"
                 },
                 {
                     "type": "patch",
                     "path": "obs-plugins-dir.patch"
-                }
-            ]
-        },
-        {
-            "name": "obs-xdg-portal",
-            "buildsystem": "meson",
-            "config-opts": [
-                "--buildtype=release"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gitlab.gnome.org/feaneron/obs-xdg-portal/-/archive/0.1.2/obs-xdg-portal-0.1.2.tar.gz",
-                    "sha256": "ef0c72680a58e8bf30c6bbc6c3daf163031c6dfc2b0c01a3b2b26fc995db145e"
                 }
             ]
         }


### PR DESCRIPTION
Wayland support is now upstream. The obs-xdg-portal plugin is now removed in favor of the upstream PipeWire capture. Browser is tentatively enabled, but browser docks are known to not work on Wayland.