### PR TITLE
use shared-modules for jack2

### DIFF
--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -56,6 +56,7 @@
         "*.la"
     ],
     "modules": [
+	"shared-modules/linux-audio/jack2.json",
         {
             "name": "x264",
             "config-opts": [
@@ -250,25 +251,6 @@
                     "url": "https://github.com/ARMmbed/mbedtls.git",
                     "commit": "1c54b5410fd48d6bcada97e30cac417c5c7eea67",
                     "tag": "v2.25.0"
-                }
-            ]
-        },
-        {
-            "name": "jack2",
-            "buildsystem": "simple",
-            "build-commands": [
-                "./waf configure --prefix=$FLATPAK_DEST",
-                "./waf build -j $FLATPAK_BUILDER_N_JOBS",
-                "./waf install"
-            ],
-            "cleanup": [
-                "*"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz",
-                    "sha256": "a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c"
                 }
             ]
         },


### PR DESCRIPTION
Note: querying for the latest tarball release using json info from GH API changes the url format from
`https://github.com/jackaudio/jack2/releases/download/v1.9.14/v1.9.14.tar.gz`
to
`https://api.github.com/repos/jackaudio/jack2/tarball/v1.9.17`.