### PR TITLE
[beta] Make VST plugins be found

### DIFF
--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -22,7 +22,8 @@
         "--talk-name=org.mate.SessionManager",
         "--talk-name=org.gnome.SessionManager",
         "--own-name=org.kde.StatusNotifierItem-2-2",
-        "--system-talk-name=org.freedesktop.Avahi"
+        "--system-talk-name=org.freedesktop.Avahi",
+        "--env=VST_PATH=/app/extensions/Plugins/lxvst"
     ],
     "add-extensions": {
         "com.obsproject.Studio.Plugin": {
@@ -50,6 +51,14 @@
             "add-ld-path": ".",
             "no-autodownload": true,
             "autodelete": true
+        },
+        "org.freedesktop.LinuxAudio.Plugins": {
+            "directory": "extensions/Plugins",
+            "version": "20.08",
+            "add-ld-path": "lib",
+            "merge-dirs": "lxvst",
+            "subdirectories": true,
+            "no-autodownload": true
         }
     },
     "cleanup": [
@@ -301,6 +310,7 @@
             ],
             "post-install": [
                 "install -d /app/plugins",
+                "install -d /app/extensions/Plugins",
                 "install -d /app/lib/blackmagic /app/lib/ndi /app/lib/v4l2sink",
                 "ln -s /app/lib/ndi/obs-ndi.so /app/lib/obs-plugins/obs-ndi.so",
                 "mkdir -p /app/share/obs/obs-plugins/obs-ndi",


### PR DESCRIPTION
Allow OBS to find the VST plugins.

Caveat: UI ~~won't display and I suspect it is because of Wayland~~ will crash and that's because of Wayland. (I had tested with some plugins that display a blank UI)

I haven't checked the stable branch.