### PR TITLE
Revert back to FFmpeg 4.3.2

### DIFF
--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -173,12 +173,7 @@
                 {
                     "type": "archive",
                     "url": "https://www.ffmpeg.org/releases/ffmpeg-4.4.tar.xz",
-                    "sha256": "06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 5405,
-                        "url-template": "https://www.ffmpeg.org/releases/ffmpeg-$version.tar.xz"
-                    }
+                    "sha256": "06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909"
                 }
             ]
         },

--- a/com.obsproject.Studio.json
+++ b/com.obsproject.Studio.json
@@ -172,8 +172,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.ffmpeg.org/releases/ffmpeg-4.4.tar.xz",
-                    "sha256": "06b10a183ce5371f915c6bb15b7b1fffbe046e8275099c96affc29e17645d909"
+                    "url": "https://www.ffmpeg.org/releases/ffmpeg-4.3.2.tar.xz",
+                    "sha256": "46e4e64f1dd0233cbc0934b9f1c0da676008cad34725113fb7f802cfa84ccddb"
                 }
             ]
         },


### PR DESCRIPTION
We can't use 4.4 as long as it regresses nvenc.