### PR TITLE
Enable all arches

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-  "only-arches": ["x86_64", "i386"],
   "automerge-flathubbot-prs": true
 }


### PR DESCRIPTION
Remove the special-casing of x86_64 and i386, which should
enable all arches to be used.